### PR TITLE
Single stream bundle update

### DIFF
--- a/shed/event_streams.py
+++ b/shed/event_streams.py
@@ -1100,6 +1100,9 @@ class BundleSingleStream(EventStream):
     """
     def __init__(self, child, control, predicate_against=('start', 'stop'),
                  **kwargs):
+        # needed if a list not supplied, assume can only be str or list/tuple
+        if isinstance(predicate_against, str):
+            predicate_against = [predicate_against]
         self.predicate_against = predicate_against
         self.control = control
         if isinstance(control, int):

--- a/shed/event_streams.py
+++ b/shed/event_streams.py
@@ -1191,7 +1191,6 @@ class BundleSingleStream(EventStream):
         for k in self.counts:
             self.counts[k] = 0
         self.issue_stop = False
-        self.start_count = 0
         # don't clear self.predicate_docs since it should be handled in
         # predicate's logic
 

--- a/shed/event_streams.py
+++ b/shed/event_streams.py
@@ -1088,7 +1088,7 @@ class BundleSingleStream(EventStream):
             self.predicate = lambda x, x2: self.start_count == self.n_hdrs
 
         self.generate_provenance()
-        self.emitted = {'start': 0, 'descriptor': 0, 'event' : 0, 'stop' : 0}
+        self.emitted = {'start': 0, 'descriptor': 0, 'event': 0, 'stop': 0}
         self.predicate_docs = dict()
         for name in predicate_against:
             self.predicate_docs[name] = deque(maxlen=2)

--- a/shed/event_streams.py
+++ b/shed/event_streams.py
@@ -1151,7 +1151,6 @@ class BundleSingleStream(EventStream):
             # Next make documents needed for this run
             # Stash the start header in case we issue a stop on the first one
             if name == 'start':
-                self.start_count = self.start_count + 1
                 # upon first start, issue a start
                 if self.counts[name] == 0:
                     return_values.append(self.start((doc,)))
@@ -1172,6 +1171,7 @@ class BundleSingleStream(EventStream):
             elif name == 'event':
                 return_values.append(self.event((doc,)))
                 self.counts[name] += 1
+            # keep track of which documents have been seen
             self.counts[name] += 1
 
         return [self.emit(r) for r in return_values]

--- a/shed/event_streams.py
+++ b/shed/event_streams.py
@@ -1102,6 +1102,7 @@ class BundleSingleStream(EventStream):
                  **kwargs):
         self.predicate_against = predicate_against
         self.control = control
+        self.start_count = 0
         if isinstance(control, int):
             EventStream.__init__(self, child=child)
             self.n_hdrs = control
@@ -1146,6 +1147,7 @@ class BundleSingleStream(EventStream):
             # Next make documents needed for this run
             # Stash the start header in case we issue a stop on the first one
             if name == 'start':
+                self.start_count = self.start_count + 1
                 # upon first start, issue a start
                 if self.emitted[name] == 0:
                     return_values.append(self.start((doc,)))
@@ -1186,6 +1188,7 @@ class BundleSingleStream(EventStream):
         for k in self.emitted:
             self.emitted[k] = 0
         self.issue_stop = False
+        self.start_count = 0
         # don't clear self.predicate_docs since it should be handled in
         # predicate's logic
 

--- a/shed/tests/test_streams.py
+++ b/shed/tests/test_streams.py
@@ -15,7 +15,7 @@
 from numpy.testing import assert_allclose, assert_equal, assert_raises
 from streamz.core import Stream
 
-import ..event_streams as es
+from .. import event_streams as es
 from ..event_streams import dstar, star
 import pytest
 from bluesky.callbacks.core import CallbackBase

--- a/shed/tests/test_streams.py
+++ b/shed/tests/test_streams.py
@@ -15,7 +15,7 @@
 from numpy.testing import assert_allclose, assert_equal, assert_raises
 from streamz.core import Stream
 
-import shed.event_streams as es
+import ..event_streams as es
 from ..event_streams import dstar, star
 import pytest
 from bluesky.callbacks.core import CallbackBase
@@ -1612,7 +1612,7 @@ def test_bundle_single_stream_callable_control(exp_db, start_uid3):
     source = Stream()
 
     dpf = es.BundleSingleStream(source,
-                                lambda x: x[0].get('uid', None) == start_uid3)
+                                lambda n, d: d.get('uid', None) == start_uid3)
 
     L = dpf.sink_to_list()
     dpf.sink(print)
@@ -1632,12 +1632,13 @@ def test_bundle_single_stream_callable_control(exp_db, start_uid3):
 
 
 def test_bundle_single_stream_callable_control2():
+    # NOTE : data is generated here
     from ..utils import to_event_model
 
     source = Stream()
 
     dpf = es.BundleSingleStream(source,
-                                lambda x: x[0].get('stitch_with_previous',
+                                lambda n, d: d.get('stitch_with_previous',
                                                    False) is False,
                                 predicate_against='start')
 
@@ -1656,7 +1657,10 @@ def test_bundle_single_stream_callable_control2():
 
     assert_docs = set()
     n_stops = 0
-    assert len(L) == ((1 + 1) + 3 * 3 + 1) + 3 + 2
+    # start, desc, 9 events, stop
+    # start, desc, 3 events, stop
+    # 18 events total
+    assert len(L) == 18
     for l in L:
         assert_docs.add(l[0])
         assert l[0]
@@ -1665,7 +1669,8 @@ def test_bundle_single_stream_callable_control2():
             assert l[1]['exit_status'] == 'success'
     for n in ['start', 'descriptor', 'event', 'stop']:
         assert n in assert_docs
-    assert n_stops == 1
+    # should have been two stops
+    assert n_stops == 2
 
 
 def test_workflow(exp_db, start_uid1):


### PR DESCRIPTION
Here are some updates I suggest:


1. Separated predicate from document creation logic in update.
    This might make it easier to read in the long run
2. Changed predicate to take two inputs for state: prevstate and nextstate
    The tricky piece with this is that if we parse the predicate on multiple
    docs, we should make sure to separate them out. Note the current
    implementation does not allow one to compare a start with a stop, but
    rather a start with another start or stop with another stop etc.
3. Made sure that the descriptor uid is updated. It seemed not to be before
4. Implicitly forced that the first doc be taken (ignoring all other docs)
    This function right now only takes one doc as input
5. Removed some stuff and condensed into a more compact variable
    For ex: start_count and emitted can be combined into emitted by allowing
    emitted to take on integer values (as opposed to bool)
6. Removed some unusued variables such as:
        self.condition = Condition()
        etc.

Let me know what you think. I think in this case this would be more productive than code review, since it involves a few suggested changes.